### PR TITLE
Fix the repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The app itself was built using the code from [https://github.com/Akryum/meteor-v
 1. Make sure you have [Meteor](https://www.meteor.com/install) installed locally.
 2. Clone this repo (and cd into the new folder):
 
-    `$ git clone git@github.com:ackzell/meteor-vue-experiment.git && cd meteor-vue-experiment`
+    `$ git clone https://github.com/ackzell/meteor-vue-experiment.git && cd meteor-vue-experiment`
 
 3. Install the `npm` dependencies
 


### PR DESCRIPTION
```
$ git clone git@github.com:ackzell/meteor-vue-experiment.git && cd meteor-vue-experiment
```
will result with:
```
Cloning into 'meteor-vue-experiment'...
Warning: Permanently added the RSA host key for IP address 'x.x.x.x' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
```